### PR TITLE
fix: previous `texts` are still in memory by changing `texts` property

### DIFF
--- a/.changeset/tall-ducks-hug.md
+++ b/.changeset/tall-ducks-hug.md
@@ -1,0 +1,5 @@
+---
+'svelte-typewrite': patch
+---
+
+fix: previous texts are still in memory after changing texts property

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm i svelte-typewrite
 
 ```svelte
 <script>
-    import { TypeWriter } from 'svelte-typewrite'
+	import { TypeWriter } from 'svelte-typewrite'
 </script>
 
 <TypeWriter texts={['lorem ipsum', 'dolor sit amet']} />

--- a/src/lib/TypeWriter.svelte
+++ b/src/lib/TypeWriter.svelte
@@ -59,7 +59,10 @@
 	const blink = (iterations: number) =>
 		new Promise<void>(async (resolve, reject) => {
 			blinkController = new AbortController()
-			const callback = () => reject(new DOMException('Blink aborted ', 'AbortError'))
+			const callback = () => {
+				blinkController.signal.removeEventListener('abort', callback)
+				reject(new DOMException('Blink aborted ', 'AbortError'))
+			}
 			blinkController.signal.addEventListener('abort', callback)
 
 			await caret.animate([{ opacity: 0 }, { opacity: 1 }, { opacity: 0 }], {

--- a/src/lib/TypeWriter.svelte
+++ b/src/lib/TypeWriter.svelte
@@ -45,7 +45,6 @@
 	$effect(() => {
 		typewriter(texts, repeat).catch((_) => {})
 		return () => {
-			textDisplayed = ' '
 			blinkController?.abort()
 			clearTimeout(timeout)
 		}

--- a/src/lib/TypeWriter.svelte
+++ b/src/lib/TypeWriter.svelte
@@ -42,7 +42,10 @@
 	let blinking: Animation
 
 	$effect(() => {
-		typewriter(texts, repeat).catch(() => {})
+		typewriter(texts, repeat).catch((e: unknown) => {
+			if (e instanceof DOMException && e.name === 'AbortError') return
+			console.error(e)
+		})
 		return () => {
 			blinking?.cancel()
 			clearTimeout(timeout)
@@ -55,8 +58,8 @@
 		})
 	}
 
-	const blink = async (iterations: number) => {
-		blinking = await caret.animate([{ opacity: 0 }, { opacity: 1 }, { opacity: 0 }], {
+	const blink = (iterations: number) => {
+		blinking = caret.animate([{ opacity: 0 }, { opacity: 1 }, { opacity: 0 }], {
 			iterations,
 			duration: blinkDuration,
 			delay: blinkDuration / 4,

--- a/src/lib/TypeWriter.svelte
+++ b/src/lib/TypeWriter.svelte
@@ -42,7 +42,7 @@
 	let blinking: Animation
 
 	$effect(() => {
-		typewriter(texts, repeat).catch((_) => {})
+		typewriter(texts, repeat).catch(() => {})
 		return () => {
 			blinking?.cancel()
 			clearTimeout(timeout)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
 		"sourceMap": true,
 		"strict": true,
 		"module": "NodeNext",
-		"moduleResolution": "NodeNext",
-	},
+		"moduleResolution": "NodeNext"
+	}
 }


### PR DESCRIPTION
Fixed by ~~clearing `textDisplayed` and~~ aborting Promise of `blink` whenever `texts` property has been changed.

### Before

[before.webm](https://github.com/satohshi/svelte-typewriter/assets/47693/4cac9016-239d-473d-a605-0353b8db3884)


### Now

[now.webm](https://github.com/satohshi/svelte-typewriter/assets/47693/d51e5697-a6bc-4c9a-a845-7e1062021436)
